### PR TITLE
修复视频解析逻辑错误

### DIFF
--- a/biliparser/strategy/video.py
+++ b/biliparser/strategy/video.py
@@ -407,7 +407,7 @@ class Video(Feed):
                     e,
                 )
             # 3.视频解析
-            if not self.infocontent and not self.infocontent.get("data"):
+            if not self.infocontent or not self.infocontent.get("data"):
                 # Video detects non-China IP
                 raise ParserException(
                     f"视频解析错误{self.aid if self.aid else self.bvid}",


### PR DESCRIPTION
## Summary
- fix logic in Video.handle when checking response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683ffde37cf88328927e218b31d8a71f